### PR TITLE
Add card_present field to the payment_method struct

### DIFF
--- a/lib/stripe/payment_methods/payment_method.ex
+++ b/lib/stripe/payment_methods/payment_method.ex
@@ -76,6 +76,7 @@ defmodule Stripe.PaymentMethod do
     :object,
     :billing_details,
     :card,
+    :card_present,
     :created,
     :customer,
     :link,


### PR DESCRIPTION
[Conflux](https://confluxlab.co/omella/cards/oml-1700)
[Notion](https://www.notion.so/omella/Tap-to-pay-224b8f80824a80ea944fe325408aa7cd?source=copy_link)

This is necessary to retrieve the payment method details by querying the provider and storing the response in our database. When a payment is processed via a terminal, the payment method data is returned in a different property than it is for card transactions, so we need to handle it accordingly.