### PR TITLE
fix: add card_present to type

### DIFF
--- a/lib/stripe/payment_methods/payment_method.ex
+++ b/lib/stripe/payment_methods/payment_method.ex
@@ -58,6 +58,7 @@ defmodule Stripe.PaymentMethod do
             phone: String.t() | nil
           },
           card: Stripe.Card.t() | nil,
+          card_present: term,
           created: Stripe.timestamp(),
           customer: Stripe.id() | Stripe.Customer.t() | nil,
           link: %{persistent_token: String.t() | nil} | nil,


### PR DESCRIPTION
Forgot to add the card_present to the type. Added it as term because it's the way that the library is [handling this now](https://github.com/beam-community/stripity-stripe/blob/main/lib/generated/payment_method.ex#L65).

original PR: #1 